### PR TITLE
Allow selection of make with ${MAKE} and suggest sensible defaults for B...

### DIFF
--- a/hippy/module/date/timelib.py
+++ b/hippy/module/date/timelib.py
@@ -5,6 +5,7 @@
 import py
 import time
 import subprocess
+import os, sys
 
 from rpython.rlib.rarithmetic import intmask
 from rpython.translator.tool.cbuild import ExternalCompilationInfo
@@ -18,7 +19,15 @@ ZONETYPE_OFFSET = 1
 
 
 LIBDIR = py.path.local(__file__).join('..', 'lib/')
-subprocess.check_call(['make', '-C', str(LIBDIR)])
+try:
+    GMAKE = os.environ["MAKE"]
+except KeyError:
+    if "bsd" in sys.platform:
+        GMAKE = "gmake"
+    else:
+        GMAKE = "make"
+
+subprocess.check_call([GMAKE, '-C', str(LIBDIR)])
 
 eci = ExternalCompilationInfo(includes=['timelib.h', 'sys/time.h', 'time.h'],
     include_dirs=[LIBDIR],


### PR DESCRIPTION
The following diff allows user to set the `MAKE` environment variable to override the make implementation used. In it's absence, a sensible default will be chosen based upon the platform (HippyVM needs GNU make, which is called `make` on Linux systems and `gmake` on BSD systems).

I did consider adding a `platform` module like in PyPy, but since this is the only place we need this, I opted to make the change inline.

This at least allows RPython to emit C code for HippyVM on my OpenBSD system. The C code does not yet build on my system, but that is a separate problem (I am looking into that).
