### PR TITLE
Document libffi-dev as a compile-time requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ There are two alternative ways to achieve this, both equally functional:
 #### 3. Get the build dependencies:
 
     pip install -r requirements.txt
-    sudo apt-get install libmysqlclient-dev libpcre3-dev librhash-dev libbz2-dev php5-cli
+    sudo apt-get install libmysqlclient-dev libpcre3-dev librhash-dev libbz2-dev php5-cli libffi-dev
 
 
 #### 4. The building process goes like this:


### PR DESCRIPTION
Without libffi-dev (Ubuntu 14.04, vagrant image, 64bit), I get the following error

```
[translation:ERROR] CompilationError: CompilationError(err="""
[translation:ERROR]     /tmp/usession-default-1/platcheck_39.c:35:17: fatal error: ffi.h: No such file or directory
[translation:ERROR]      #include <ffi.h>
[translation:ERROR]                      ^
[translation:ERROR]     compilation terminated.
[translation:ERROR]     """)
```

Installing libffi-dev removes this error and allows compilation to succeed.
