### PR TITLE
Fixed bug that causes parsing of the string "$x{" to fail.

### DIFF
--- a/hippy/lexer.py
+++ b/hippy/lexer.py
@@ -328,7 +328,7 @@ RULES = [(parse_regex(rule), name) for rule, name in _RULES]
 _RULES_FOR_DOUBLE_QUOTE = (
     ("\$[a-zA-Z_][0-9a-zA-Z_]*(->[a-zA-Z_][0-9a-zA-Z_]*)?", 'T_VARIABLE'),
     (r"\{\$|\$\{", "T_DOLLAR_OPEN_CURLY_BRACES"),
-    (r"([^\"\$\{\\]|\\.|\$[^a-zA-Z\"\{]|{[^\$])+", "T_ENCAPSED_AND_WHITESPACE"),
+    (r"([^\"\$\{\\]|\\.|\$[^a-zA-Z\"\{]|{[^\$\"])+|{", "T_ENCAPSED_AND_WHITESPACE"),
     (r"\$", "T_DOLLAR"),
     ('"', '"'),
 )

--- a/testing/test_parse.py
+++ b/testing/test_parse.py
@@ -51,6 +51,11 @@ class TestParseDoubleQuote(object):
                                             ConstantInt(3))])
         assert parse_doublequoted("a{$x[3]}") == expected
 
+    def test_brackets_bug(self):
+        expected = DoubleQuotedStr([NamedVariable("x"),
+                                    ConstantStr("{")])
+        assert parse_doublequoted("$x{") == expected
+
     def test_interpolated_str_re(self):
         r = parse_doublequoted("^(?:$langtag|$privateUse)$")
         expected = DoubleQuotedStr([ConstantStr("^(?:"),


### PR DESCRIPTION
Before the lexer would lex the line

echo "$x{";

into the tokens

QUOTE ("), T_VARIABLE ($x), T_ENCAPSED_AND_WHITESPACE ({";)

whereas it should do something in the lines of

QUOTE ("), T_VARIABLE ($x), T_ENCAPSED_AND_WHITESPACE ({), QUOTE ("), T_SEMICOLON (;)
