### PR TITLE
Fixed encoding and decoding of cookie values

### DIFF
--- a/hippy/interpreter.py
+++ b/hippy/interpreter.py
@@ -412,7 +412,7 @@ class Interpreter(object):
                 if len(l2) != 2:
                     # XXX issue a warning?
                     continue
-                d[l2[0]] = space.wrap(l2[1])
+                d[l2[0]] = space.wrap(hippy.module.url._rawurldecode(l2[1]))
             return space.new_array_from_rdict(d)
         return space.w_Null
 

--- a/hippy/module/standard/network/funcs.py
+++ b/hippy/module/standard/network/funcs.py
@@ -8,7 +8,7 @@ from rpython.rlib import rsocket
 from rpython.rlib.rstring import StringBuilder
 from hippy.module.date.funcs import _strftime
 from hippy.objects.resources.socket_resource import W_SocketResource
-from hippy.module.url import urlsplit
+from hippy.module.url import urlsplit, _rawurlencode
 
 
 def checkdnsrr():
@@ -272,7 +272,7 @@ def setcookie(interp, name, value="", expire=0, path=None,
               domain=None, secure=False, httponly=False):
     """ Send a cookie"""
     c = StringBuilder()
-    c.append("Set-Cookie: %s=%s" % (name, value))
+    c.append("Set-Cookie: %s=%s" % (name, _rawurlencode(value)))
     if expire > 0:
         d = _strftime(interp, True, '%a, %d %b %Y %H:%M:%S', expire)
         c.append("; Expires=%s" % d)

--- a/testing/test_cgi.py
+++ b/testing/test_cgi.py
@@ -60,3 +60,20 @@ class TestCGI(BaseTestInterpreter):
         echo $_SESSION["a"];
         ''', cgi=True)
         assert self.unwrap(output[0]) == 13
+
+    def test_encode_cookies(self):
+        # no cookie set
+        self.run('''
+        header("Content-type: text/css");
+        setcookie("a","b=");
+        ''')
+        assert self.interp.sent_headers == ['Content-type: text/css',
+                                            'Set-Cookie: a=b%3D']
+
+    def test_decode_cookies(self):
+        os.environ['HTTP_COOKIE'] = 'a=b%3D'
+
+        output = self.run('''
+        echo $_COOKIE["a"];
+        ''', cgi=True)
+        assert self.unwrap(output[0]) == "b="


### PR DESCRIPTION
The value portion of a cookie has to automatically be urlencoded when sent and
urldecoded when received.

See: http://php.net/manual/en/function.setcookie.php
