### PR TITLE
Remove unused unique_array parameter from _setitem_str()

### DIFF
--- a/hippy/interpreter.py
+++ b/hippy/interpreter.py
@@ -142,8 +142,7 @@ class W_Globals(W_RDictArrayObject):
         assert isinstance(r_var, W_Reference)
         self.dct_w[name] = r_var
 
-    def _setitem_str(self, key, w_value, as_ref,
-                     unique_array=False, unique_item=False):
+    def _setitem_str(self, key, w_value, as_ref, unique_item=False):
         dct_w = self.dct_w
         if not as_ref:
             try:

--- a/hippy/objects/arrayobject.py
+++ b/hippy/objects/arrayobject.py
@@ -269,8 +269,7 @@ class W_ArrayObject(W_Object):
     def _setitem_int(self, index, w_value, as_ref, unique_item=False):
         raise NotImplementedError("abstract")
 
-    def _setitem_str(self, key, w_value, as_ref,
-                     unique_array=False, unique_item=False):
+    def _setitem_str(self, key, w_value, as_ref, unique_item=False):
         # Note: might be occasionally called with a string like "5" too
         raise NotImplementedError("abstract")
 
@@ -502,8 +501,7 @@ class W_ListArrayObject(W_ArrayObject):
         self.lst_w[index] = w_value
         return self
 
-    def _setitem_str(self, key, w_value, as_ref,
-                     unique_array=False, unique_item=False):
+    def _setitem_str(self, key, w_value, as_ref, unique_item=False):
         try:
             i = try_convert_str_to_int(key)
         except ValueError:
@@ -696,8 +694,7 @@ class W_RDictArrayObject(W_ArrayObject):
     def _setitem_int(self, index, w_value, as_ref, unique_item=False):
         return self._setitem_str(str(index), w_value, as_ref, unique_item)
 
-    def _setitem_str(self, key, w_value, as_ref,
-                     unique_array=False, unique_item=False):
+    def _setitem_str(self, key, w_value, as_ref, unique_item=False):
         # If overwriting an existing W_Reference object, we only update
         # the value in the reference and return 'self'.
         if not as_ref:


### PR DESCRIPTION
@ltratt @vext01 Please check that it doesn't cause issues on your side, beyond having to also remove the param from your array subclasses.
