### PR TITLE
Fix Regex Module

### DIFF
--- a/hippy/module/regex/_pcre.py
+++ b/hippy/module/regex/_pcre.py
@@ -11,7 +11,7 @@ void hippy_pcre_free2(pcre *p, pcre_extra *x);
 source = """
 #include <string.h>
 
-void hippy_pcre_free2(pcre *p, pcre_extra *x) {
+RPY_EXPORTED void hippy_pcre_free2(pcre *p, pcre_extra *x) {
 #ifdef PCRE_CONFIG_JIT
     pcre_free_study(x);
 #else
@@ -20,7 +20,7 @@ void hippy_pcre_free2(pcre *p, pcre_extra *x) {
     pcre_free(p);
 }
 
-pcre_extra* hippy_pcre_extra_malloc()
+RPY_EXPORTED pcre_extra* hippy_pcre_extra_malloc()
 {
     pcre_extra* res;
     res = (pcre_extra*)pcre_malloc(sizeof(pcre_extra));


### PR DESCRIPTION
The regex module tests are failing like this:

```
E           NotImplementedError: function 'hippy_pcre_extra_malloc' not found in any of the libraries ('pcre', '/tmp/usession-default-9/shared_cache/externmod.so')
```

This is because the function is not exposed in the resulting shared library.


I would have used `export_symbols` kwarg to the eci, but it seems it has been removed (https://bitbucket.org/pypy/pypy/diff/rpython/translator/tool/cbuild.py?diff2=aab7e664e48a&at=kill-exported-symbols-list).

Here is the eci for the regex module:

```
eci = ExternalCompilationInfo(includes=includes, libraries=libraries,
                              post_include_bits=post_include_bits,
                              separate_module_sources=[source])
```

 There is a comment in `rpython/translator/tool/cbuild.py`:

```
(export_symbols: killed, replaced by @rlib.entrypoint.export_symbol)
```

however, I don't understand how/where I would apply this decorator.

FWIW, the change below makes the tests pass, proving that the symbols are not exported. I don't think this is the correct fix however.