### PR TITLE
Fix CFFI under PyHyp

### DIFF
--- a/hippy/main.py
+++ b/hippy/main.py
@@ -60,10 +60,7 @@ def setup_pypy_for_pyhyp(py_space):
 
   # Should always be able to import Python modules in CWD.
   w_sys_path = py_space.getattr(w_sys, py_space.wrap("path"))
-  w_sys_path_append = py_space.getattr(w_sys_path, py_space.wrap("append"))
-  from pypy.interpreter.argument import Arguments
-  py_space.call_args(w_sys_path_append,
-                     Arguments(py_space, [py_space.wrap(".")]))
+  py_space.call_method(w_sys_path, 'append', py_space.wrap("."))
 
   # Set sys.executable in PyPy -- some modules rely upon this existing.
   py_space.setattr(w_sys, py_space.wrap("executable"),

--- a/hippy/main.py
+++ b/hippy/main.py
@@ -33,8 +33,10 @@ def _run_fastcgi_server(server_port):
     print "Running fcgi server on port %d" % (server_port,)
     return run_fcgi_server(port=server_port)
 
-def mk_entry_point(py_space=None):
-  # XXX 2 space indent to make merging with master less painful XXX
+def setup_pypy_for_pyhyp(py_space):
+  """Respoonsible for setting PyPy up when running in PyHyp.
+  This stuff is mostly needed as PyPy's app_main does not get a chance
+  to run."""
 
   # equivalent to the hack in app_main.py of PyPy, albiet interp-level.
   w_sys = py_space.sys
@@ -43,6 +45,33 @@ def mk_entry_point(py_space=None):
   if not py_space.is_true(w_in):
     rl = py_space.sys.get("setrecursionlimit")
     py_space.call(rl, py_space.newlist([py_space.wrap(5000)]))
+
+  w_sys.pyhyp_enabled = True
+
+  # This stuff is needed to set sys.path and sys.exec_path
+  # CFFI needs this, for example.
+  from pypy.module.sys.initpath import pypy_find_stdlib
+  res = pypy_find_stdlib(py_space, None)
+
+  if res == py_space.w_None:
+      print("To run PyHyp, you must set PYPY_PREFIX to the directory "
+            "containing the PyPy libraries")
+      sys.exit(1)
+
+  # Should always be able to import Python modules in CWD.
+  w_sys_path = py_space.getattr(w_sys, py_space.wrap("path"))
+  w_sys_path_append = py_space.getattr(w_sys_path, py_space.wrap("append"))
+  from pypy.interpreter.argument import Arguments
+  py_space.call_args(w_sys_path_append,
+                     Arguments(py_space, [py_space.wrap(".")]))
+
+  # Set sys.executable in PyPy -- some modules rely upon this existing.
+  py_space.setattr(w_sys, py_space.wrap("executable"),
+                   py_space.wrap(os.path.abspath(sys.argv[0])))
+
+def mk_entry_point(py_space=None):
+  # XXX 2 space indent to make merging with master less painful XXX
+  setup_pypy_for_pyhyp(py_space)
 
   def entry_point(argv):
     i = 1

--- a/hippy/module/pypy_bridge/bridge.py
+++ b/hippy/module/pypy_bridge/bridge.py
@@ -448,7 +448,6 @@ def call_py_func(interp, w_func_or_w_name, w_args, w_kwargs):
     assert w_py_rv is not None
     return w_py_rv.to_php(interp)
 
-
 from pypy.interpreter.pytraceback import PyTraceback
 class DummyPyTraceback(PyTraceback):
 

--- a/hippy/module/pypy_bridge/py_adapters.py
+++ b/hippy/module/pypy_bridge/py_adapters.py
@@ -574,10 +574,16 @@ class W_PyExceptionAdapter(W_ExceptionObject):
         if tb is not None:
             assert isinstance(tb, PyTraceback)
             py_frame = tb.frame
-            php_frame = py_frame.php_scope.ph_frame
+            php_scope = py_frame.php_scope
+            if php_scope is not None:
+                php_frame = py_frame.php_scope.ph_frame
+            else:
+                # This Python code has no parent Python frame,
+                # per-se. This happens when an exception occurs
+                # inside PyHyp's import_py_mod().
+                php_frame = php_interp.topframeref()
         else:
-            # Python frame was never opened.
-            # e.g. import_py_mod raised
+            # This case can also occur if import_py_mod() raised.
             php_frame = php_interp.topframeref()
 
         filename, php_funcname, line = php_frame.get_position()

--- a/hippy/module/standard/misc/funcs.py
+++ b/hippy/module/standard/misc/funcs.py
@@ -198,3 +198,7 @@ def usleep(interp, microseconds):
 def clock_gettime_monotonic(interp):
     """Read the monotonic system clock and return a Python float"""
     return interp.space.wrap(_clock_gettime_monotonic())
+
+@wrap(['interp'])
+def is_pyhyp_enabled(interp):
+    return interp.space.wrap(interp.py_space.sys.is_pyhyp_enabled())

--- a/testing/test_interpreter.py
+++ b/testing/test_interpreter.py
@@ -54,6 +54,8 @@ class BaseTestInterpreter(object):
     def init_space(self):
         self.space = getspace()
         self.py_space = SHARED_PY_SPACE
+        from hippy.main import setup_pypy_for_pyhyp
+        setup_pypy_for_pyhyp(self.py_space)
         if option.runappdirect:
             self.engine = self.DirectRunner(self.space, self.py_space)
         else:


### PR DESCRIPTION
Many aspects to this:
 * Fix bogus PHP frame lookup in exception code (found during fixing cffi).
 * Correctly set sys.prefix and sys.exec_prefix.
   The user needs to supply PYPY_PREFIX.
 * Allow importing of modules from CWD.
 * Ensure the old CFFI interface is not usable from PyHyp.

As of yet, I have been unable to test CFFI. Seems like this would need
some more work (hence the one xfailing test). If there is interest in
this, let's do it in another PR.

Also had problems testing the bogus frame lookup due to some weirdness
in py.test.

Accompanies: https://bitbucket.org/softdevteam/pypy-hippy-bridge/pull-requests/2/hippy_bridge_sprint_cffi

Pushing on as I have already spent too long on this.

Assuming it translates (translating now) OK?