### PR TITLE
Pypy bridge foreign exn tests

### DIFF
--- a/hippy/error.py
+++ b/hippy/error.py
@@ -55,7 +55,6 @@ class Throw(Exception):
         # We will need to chop off items from the PHP backtrace, from
         # this frame upwards. Therefore, we first walk up the stack seeing
         # how deep we are at this point.
-        # Yeh, this is slow, but it is an *exception* case after all.
         n_chop = 0
         f = interp.topframeref()
         while True:
@@ -66,7 +65,6 @@ class Throw(Exception):
                 break
 
         # And chop
-        #assert n_chop <= len(w_exc.traceback)
         end = len(w_exc.traceback) - n_chop
         assert end >= 0
         traceback = w_exc.traceback[0:end]

--- a/testing/test_pypy_bridge_scope.py
+++ b/testing/test_pypy_bridge_scope.py
@@ -1167,7 +1167,7 @@ def f():
         ''')
         assert php_space.str_w(output[0]) == "most illogical"
 
-    # XXX: We yet catch a foreign PHP exception under Python by name.
+    # XXX: We can't yet catch a foreign PHP exception under Python by name.
     @pytest.mark.xfail
     def test_raise_foregin_exception007(self, php_space):
         output = self.run(r'''


### PR DESCRIPTION
This and https://bitbucket.org/softdevteam/pypy-hippy-bridge/pull-requests/3/fix-for-throwing-foreign-exceptions/diff fixes a bug and tests more exception paths with regards to foreign exceptions. The fix itself is in the PyPy change.

Sorry for the delay, it took several attempts to get right, and it turns out the fix is a one liner.

Looks OK?

*Please don't merge yet, as this has not yet been benchmarked. I will report back with benchmark outcomes soon*
