### PR TITLE
Make PYPY_PREFIX (needed by cffi) a runtime lookup.

### DIFF
--- a/hippy/main.py
+++ b/hippy/main.py
@@ -62,7 +62,7 @@ def check_pypy_prefix_env(py_space):
     from pypy.module.sys.initpath import pypy_find_stdlib
     res = pypy_find_stdlib(py_space, None)
 
-    if res == py_space.w_None:
+    if py_space.is_w(res, py_space.w_None):
         print("To run PyHyp, you must set PYPY_PREFIX to the directory "
               "containing the PyPy libraries")
         return False

--- a/hippy/main.py
+++ b/hippy/main.py
@@ -48,16 +48,6 @@ def setup_pypy_for_pyhyp(py_space):
 
   w_sys.pyhyp_enabled = True
 
-  # This stuff is needed to set sys.path and sys.exec_path
-  # CFFI needs this, for example.
-  from pypy.module.sys.initpath import pypy_find_stdlib
-  res = pypy_find_stdlib(py_space, None)
-
-  if res == py_space.w_None:
-      print("To run PyHyp, you must set PYPY_PREFIX to the directory "
-            "containing the PyPy libraries")
-      sys.exit(1)
-
   # Should always be able to import Python modules in CWD.
   w_sys_path = py_space.getattr(w_sys, py_space.wrap("path"))
   py_space.call_method(w_sys_path, 'append', py_space.wrap("."))
@@ -66,11 +56,26 @@ def setup_pypy_for_pyhyp(py_space):
   py_space.setattr(w_sys, py_space.wrap("executable"),
                    py_space.wrap(os.path.abspath(sys.argv[0])))
 
+def check_pypy_prefix_env(py_space):
+    # This stuff is needed to set sys.path and sys.exec_path
+    # CFFI needs this, for example.
+    from pypy.module.sys.initpath import pypy_find_stdlib
+    res = pypy_find_stdlib(py_space, None)
+
+    if res == py_space.w_None:
+        print("To run PyHyp, you must set PYPY_PREFIX to the directory "
+              "containing the PyPy libraries")
+        return False
+    return True
+
 def mk_entry_point(py_space=None):
   # XXX 2 space indent to make merging with master less painful XXX
   setup_pypy_for_pyhyp(py_space)
 
   def entry_point(argv):
+    if not check_pypy_prefix_env(py_space):
+      return 1
+
     i = 1
     fname = None
     gcdump = None


### PR DESCRIPTION
It turns out we were baking the compile time PYPY_PREFIX into the pyhyp binary. This fixes this.

OK?