### PR TITLE
Add a test that checks pyhyp preserves PHP function args error behaviours

### DIFF
--- a/testing/test_pypy_bridge.py
+++ b/testing/test_pypy_bridge.py
@@ -1831,6 +1831,22 @@ class TestPyPyBridge(BaseTestInterpreter):
         #  i.e. didn't crash
 
 
+    # Not really excercising pyhyp, but can't hurt.
+    def test_range_to_py_wrong_args(self, php_space):
+        warns = ["Warning: range() expects at least 2 parameters, 1 given"]
+        output = self.run(r'''
+
+        $pysrc = <<<EOD
+        def f(it):
+            return isinstance(it, bool)
+        EOD;
+        $f = compile_py_func($pysrc);
+
+        echo $f(range(1)); // range returns false due to wrong args
+        ''', warns)
+        assert php_space.is_true(output[0])
+
+
 class TestPyPyBridgeInterp(object):
 
     def test_php_code_cache(self):


### PR DESCRIPTION
In response to a bug report (which i filed a long time ago). Although I couldn't reproduce the original crash, I thought I had found another bug. calling range(3) in PHP returned false. Turns out this is standard PHP semantics. Doesn't hurt to have this test.