### PR TITLE
Pypy bridge str py mod

### DIFF
--- a/hippy/builtin.py
+++ b/hippy/builtin.py
@@ -854,6 +854,7 @@ class BuiltinFunction(AbstractFunction):
     _immutable_fields_ = ['runner']
 
     def __init__(self, funcname, runner):
+        AbstractFunction.__init__(self)
         self.name = funcname.split('::')[-1]
         self._fullname = funcname
         self.runner = runner

--- a/hippy/function.py
+++ b/hippy/function.py
@@ -59,7 +59,11 @@ class AbstractFunction(W_Root):
     name = "??"
 
     _immutable_fields_ = ['name']
-    _attrs_ = ('name',)
+    _attrs_ = ('name', 'closuredecls')
+
+    def __init__(self):
+        # Only used for non-builtins
+        self.closuredecls = None
 
     def get_identifier(self):
         return self.name.lower()

--- a/hippy/module/pypy_bridge/php_adapters.py
+++ b/hippy/module/pypy_bridge/php_adapters.py
@@ -5,19 +5,13 @@ wrap PHP objects for use within Python programs.
 
 from pypy.interpreter.baseobjspace import W_Root
 from pypy.interpreter.typedef import TypeDef
-from pypy.interpreter.gateway import interp2app, unwrap_spec
-from pypy.interpreter.function import Function as Py_Function
-from pypy.interpreter.argument import Arguments
-from pypy.interpreter.error import OperationError
+from pypy.interpreter.gateway import interp2app
 
 from hippy.objects.reference import W_Reference
-from hippy.klass import def_class
-from hippy.builtin import wrap_method
 from hippy.error import Throw, VisibilityError
 from hippy.module.pypy_bridge.util import _raise_py_bridgeerror
-from hippy.builtin import wrap_method, ThisUnwrapper
 
-from rpython.rlib import jit, rerased, unroll
+from rpython.rlib import jit
 
 
 class W_PHPGenericAdapter(W_Root):
@@ -452,7 +446,6 @@ class W_PHPUnboundMethAdapter(W_Root):
 
     def to_php(self, interp):
         # This doesn't really make sense, so just raise an exception.
-        from hippy.objects.closureobject import new_closure
         _raise_py_bridgeerror(self.space, "Cannot unwrap unbound PHP method.")
 
 

--- a/hippy/module/pypy_bridge/php_adapters.py
+++ b/hippy/module/pypy_bridge/php_adapters.py
@@ -384,7 +384,12 @@ class W_PHPUnboundMethAdapter(W_Root):
         self.w_php_meth = w_php_meth
 
     def get_wrapped_php_obj(self):
-        return self.w_php_meth
+        # This is awkward since a Python Method is not derived from PHP's
+        # W_Root. This means we would have to special case everywhere this
+        # needs to be called. Since this is such a rare use-case, we
+        # block it for now.
+        _raise_py_bridgeerror(
+            self.space, "Illegal operation on wrapped unbound PHP method")
 
     def get_php_interp(self):
         return self.space.get_php_interp()

--- a/hippy/module/pypy_bridge/php_adapters.py
+++ b/hippy/module/pypy_bridge/php_adapters.py
@@ -351,13 +351,7 @@ class W_PHPFuncAdapter(W_Root):
         # not first class.The best we can do is a closure.
         from hippy.objects.closureobject import new_closure
         from hippy.builtin import BuiltinFunction
-        if isinstance(self.w_php_func, BuiltinFunction):
-            # PHP builtins can not be stashed inside of a PHP closure!
-            from hippy.module.pypy_bridge.bridge import _raise_php_bridgeexception
-            _raise_php_bridgeexception(
-                interp, "Can't pass PHP builtin's from Python to PHP")
-        else:
-            return new_closure(interp.space, self.w_php_func, None)
+        return new_closure(interp.space, self.w_php_func, None)
 
     def descr_str(self):
         return self.space.wrap(self.w_php_func.name)

--- a/hippy/module/pypy_bridge/php_adapters.py
+++ b/hippy/module/pypy_bridge/php_adapters.py
@@ -356,7 +356,14 @@ class W_PHPFuncAdapter(W_Root):
         # we can't just unwrap the function, since PHP funcs are
         # not first class.The best we can do is a closure.
         from hippy.objects.closureobject import new_closure
-        return new_closure(interp.space, self.w_php_func, None)
+        from hippy.builtin import BuiltinFunction
+        if isinstance(self.w_php_func, BuiltinFunction):
+            # PHP builtins can not be stashed inside of a PHP closure!
+            from hippy.module.pypy_bridge.bridge import _raise_php_bridgeexception
+            _raise_php_bridgeexception(
+                interp, "Can't pass PHP builtin's from Python to PHP")
+        else:
+            return new_closure(interp.space, self.w_php_func, None)
 
     def descr_str(self):
         return self.space.wrap(self.w_php_func.name)

--- a/hippy/module/pypy_bridge/py_adapters.py
+++ b/hippy/module/pypy_bridge/py_adapters.py
@@ -93,9 +93,11 @@ class W_PyGenericAdapter(W_InstanceObject):
     def to_py(self, interp, w_php_ref=None):
         return self.w_py_inst
 
-    def as_string(self, space, quiet=False):
-        """ Tells PHP how to str_w this should we wrap a string """
-        return self.w_py_inst.to_php(self.interp)
+
+    def str(self, space, quiet=False):
+        py_space = self.interp.py_space
+        w_py_str = py_space.str(self.w_py_inst)
+        return py_space.str_w(w_py_str)
 
 @wrap_method(['interp', ThisUnwrapper(W_PyGenericAdapter), str],
         name='GenericPyProxy::__get')
@@ -237,6 +239,11 @@ class W_PyFuncGlobalAdapter(AbstractFunction):
     def to_py(self, interp, w_php_ref=None):
         return self.w_py_callable
 
+    def str(self, space, quiet=False):
+        py_space = self.interp.py_space
+        w_py_str = py_space.str(self.w_py_callable)
+        return py_space.str_w(w_py_str)
+
 class W_PyMethodFuncAdapter(W_PyFuncGlobalAdapter):
     """Only exists because method indicies for methods are skewed by one
     between Python and PHP. In PHP $this is implicit"""
@@ -291,6 +298,12 @@ class W_PyFuncAdapter(W_InstanceObject):
     def get_wrapped_py_obj(self):
         return self.w_py_func
 
+
+    def str(self, space, quiet=False):
+        py_space = self.interp.py_space
+        w_py_str = py_space.str(self.w_py_func)
+        return py_space.str_w(w_py_str)
+
 k_PyFuncAdapter = def_class('PyFunc', [])
 
 def new_adapted_py_func(interp, w_py_func):
@@ -328,6 +341,11 @@ class W_PyModAdapter(WPh_Object):
 
     def to_py(self, interp, w_php_ref=None):
         return self.w_py_mod
+
+
+    def str(self, space, quiet=False):
+        w_py_str = self.py_space.str(self.w_py_mod)
+        return self.py_space.str_w(w_py_str)
 
 class W_PyListAdapterIterator(BaseIterator):
     _immutable_fields_ = ["py_space", "storage_w"]
@@ -562,6 +580,11 @@ class W_PyExceptionAdapter(W_ExceptionObject):
     def __init__(self, klass, initial_storage):
         W_ExceptionObject.__init__(self, klass, initial_storage)
         self.w_py_exn = None # set elsewhere
+        self.interp = None   # also set elsewhere
+
+    def set_w_py_exn(self, interp, w_py_exn):
+        self.interp = interp
+        self.w_py_exn = w_py_exn
 
     def set_exninfo(self, php_interp, w_py_operr):
         """Sets useful debugging info"""
@@ -600,6 +623,12 @@ class W_PyExceptionAdapter(W_ExceptionObject):
 
     def to_py(self, interp, w_php_ref=None):
         return self.w_py_exn
+
+
+    def str(self, space, quiet=False):
+        py_space = self.interp.py_space
+        w_py_str = py_space.str(self.w_py_exn)
+        return py_space.str_w(w_py_str)
 
 from hippy.builtin_klass import k_Exception
 k_PyExceptionAdapter = def_class('PyException',
@@ -665,6 +694,12 @@ class W_PyClassAdapter(W_InstanceObject):
 
     def to_py(self, interp, w_php_ref=None):
         return self.w_py_kls
+
+
+    def str(self, space, quiet=False):
+        py_space = self.interp.py_space
+        w_py_str = py_space.str(self.w_py_kls)
+        return py_space.str_w(w_py_str)
 
 k_PyClassAdapter = def_class('PyClassAdapter',
                              [], [],

--- a/hippy/objects/closureobject.py
+++ b/hippy/objects/closureobject.py
@@ -1,7 +1,7 @@
 from hippy.objects.instanceobject import W_InstanceObject
 from hippy.klass import W_InvokeCall, def_class
-from hippy.builtin import wrap_method, ThisUnwrapper
-from hippy.function import Function
+from hippy.builtin import wrap_method, ThisUnwrapper, BuiltinFunction
+from hippy.function import Function, AbstractFunction
 
 class W_CallClosure(W_InvokeCall):
     def __init__(self, klass, call_func, w_obj, closure):
@@ -17,9 +17,12 @@ class W_CallClosure(W_InvokeCall):
 
 class W_ClosureObject(W_InstanceObject):
     def __init__(self, func, klass, storage_w, w_this=None, static=False):
-        assert isinstance(func, Function)
+        assert isinstance(func, AbstractFunction)
         self._func = func
-        self.closure_args = [None] * len(func.closuredecls)
+        if isinstance(func, Function):
+            self.closure_args = [None] * len(func.closuredecls)
+        else:
+            self.closure_args = []
         W_InstanceObject.__init__(self, klass, storage_w)
         self.w_this = w_this
         self.static = static

--- a/testing/test_pypy_bridge_conversion.py
+++ b/testing/test_pypy_bridge_conversion.py
@@ -285,15 +285,17 @@ class TestPyPyBridgeConversions(BaseTestInterpreter):
 
     def test_php_builtin_func_to_py_to_php(self, php_space):
         output = self.run(r'''
-        $pysrc = "def f(): return array_shift";
+        $pysrc = "def f(): return array_keys";
         $f = compile_py_func($pysrc);
 
-        try {
-            $f();
-            echo "nope!";
-        } catch(BridgeException $e) {
-            echo $e->getMessage();
-        }
+        $ar_k = $f();
+        $ar = array("a" => 1, "t" => 666);
+        $ar2 = $ar_k($ar);
+
+        echo count($ar2);
+        echo $ar2[0];
+        echo $ar2[1];
         ''')
-        err_s = "Can't pass PHP builtin's from Python to PHP"
-        assert php_space.str_w(output[0]) == err_s
+        assert php_space.int_w(output[0]) == 2
+        assert php_space.str_w(output[1]) == "a"
+        assert php_space.str_w(output[2]) == "t"

--- a/testing/test_pypy_bridge_conversion.py
+++ b/testing/test_pypy_bridge_conversion.py
@@ -282,3 +282,18 @@ class TestPyPyBridgeConversions(BaseTestInterpreter):
         echo $g(2);
         ''')
         assert php_space.int_w(output[0]) == 5
+
+    def test_php_builtin_func_to_py_to_php(self, php_space):
+        output = self.run(r'''
+        $pysrc = "def f(): return array_shift";
+        $f = compile_py_func($pysrc);
+
+        try {
+            $f();
+            echo "nope!";
+        } catch(BridgeException $e) {
+            echo $e->getMessage();
+        }
+        ''')
+        err_s = "Can't pass PHP builtin's from Python to PHP"
+        assert php_space.str_w(output[0]) == err_s

--- a/testing/test_pypy_bridge_special_methods.py
+++ b/testing/test_pypy_bridge_special_methods.py
@@ -17,3 +17,144 @@ class TestPyPyBridgeSpecialMethods(BaseTestInterpreter):
             echo($f());
         ''')
         assert php_space.str_w(output[0]) == "C.__toString"
+
+    def test_str_of_py_mod_in_php(self, php_space):
+        output = self.run('''
+            $sys = import_py_mod("sys");
+            echo $sys;
+            echo (string) $sys;
+        ''')
+        expect = "<module 'sys' (built-in)>"
+        assert php_space.str_w(output[0]) == expect
+        assert php_space.str_w(output[1]) == expect
+
+    def test_str_of_py_func_in_php(self, php_space):
+        output = self.run('''
+            $f = compile_py_func("def f(): pass");
+            echo $f;
+            echo (string) $f;
+        ''')
+        expect  = "<function f at "
+        assert php_space.str_w(output[0]).startswith(expect)
+        assert php_space.str_w(output[1]).startswith(expect)
+
+
+    def test_str_of_py_meth_in_php001(self, php_space):
+        output = self.run('''
+            $pysrc = <<<EOD
+            def f():
+                class C(object):
+                    def meth(self): pass
+                return C.meth
+            EOD;
+            $f = compile_py_func($pysrc);
+            $m = $f();
+            echo $m;
+            echo (string) $m;
+        ''')
+        expect  = "<unbound method C.meth>"
+        assert php_space.str_w(output[0]) == expect
+        assert php_space.str_w(output[1]) == expect
+
+    def test_str_of_py_meth_in_php002(self, php_space):
+        output = self.run('''
+            $pysrc = <<<EOD
+            def f():
+                class C(object):
+                    def meth(self): pass
+                return C().meth
+            EOD;
+            $f = compile_py_func($pysrc);
+            $m = $f();
+            echo $m;
+            echo (string) $m;
+        ''')
+        expect  = "<bound method C.meth of "
+        assert php_space.str_w(output[0]).startswith(expect)
+        assert php_space.str_w(output[1]).startswith(expect)
+
+
+    def test_str_of_py_inst_in_php(self, php_space):
+        output = self.run('''
+            $pysrc = <<<EOD
+            def f():
+                class C(object): pass
+                return C()
+            EOD;
+            $f = compile_py_func($pysrc);
+            $c = $f();
+            echo $c;
+            echo (string) $c;
+        ''')
+        expect  = "<__builtin__.C object at "
+        assert php_space.str_w(output[0]).startswith(expect)
+        assert php_space.str_w(output[1]).startswith(expect)
+
+
+    def test_str_of_py_list_in_php(self, php_space):
+        # It's illegal to convert an array to a string in PHP
+        errs = ["Notice: Array to string conversion"]
+        output = self.run('''
+            $pysrc = <<<EOD
+            def f():
+                return [1, 2, 3]
+            EOD;
+            $f = compile_py_func($pysrc);
+            $a = $f();
+            echo $a;
+            echo (string) $a;
+        ''', errs)
+        expect = "Array"
+        assert php_space.str_w(output[0]) == expect
+        assert php_space.str_w(output[1]) == expect
+
+
+    def test_str_of_py_dict_in_php(self, php_space):
+        # It's illegal to convert an array to a string in PHP
+        errs = ["Notice: Array to string conversion"]
+        output = self.run('''
+            $pysrc = <<<EOD
+            def f():
+                return {1: 'a', 2: 'b'}
+            EOD;
+            $f = compile_py_func($pysrc);
+            $a = $f();
+            echo $a;
+            echo (string) $a;
+        ''', errs)
+        expect = "Array"
+        assert php_space.str_w(output[0]) == expect
+        assert php_space.str_w(output[1]) == expect
+
+
+    def test_str_of_py_exn_in_php(self, php_space):
+        output = self.run('''
+            $pysrc = <<<EOD
+            def f():
+                return IndexError("questionable index")
+            EOD;
+            $f = compile_py_func($pysrc);
+            $a = $f();
+            echo $a;
+            echo (string) $a;
+        ''')
+        expect = "questionable index"
+        assert php_space.str_w(output[0]) == expect
+        assert php_space.str_w(output[1]) == expect
+
+
+    def test_str_of_py_class_in_php(self, php_space):
+        output = self.run('''
+            $pysrc = <<<EOD
+            def f():
+                class C(object): pass
+                return C
+            EOD;
+            $f = compile_py_func($pysrc);
+            $c = $f();
+            echo $c;
+            echo (string) $c;
+        ''')
+        expect = "<class 'C'>"
+        assert php_space.str_w(output[0]) == expect
+        assert php_space.str_w(output[1]) == expect

--- a/testing/test_pypy_bridge_special_methods.py
+++ b/testing/test_pypy_bridge_special_methods.py
@@ -237,3 +237,17 @@ class TestPyPyBridgeSpecialMethods(BaseTestInterpreter):
         echo $f();
         ''')
         assert php_space.str_w(output[0]) == "<PHPRef>"
+
+    def test_id_of_php_unbound_meth_in_py(self, php_space):
+        output = self.run(r'''
+        class A { function g() {} };
+        $pysrc = "def f(): return id(A.g)";
+        $f = compile_py_func($pysrc);
+        try {
+            $f();
+            echo "fail";
+        } catch (PyException $e) {
+            echo $e->getMessage();
+        }
+        ''')
+        assert php_space.str_w(output[0]) == "BridgeError: Illegal operation on wrapped unbound PHP method"


### PR DESCRIPTION
In response to: https://bitbucket.org/softdevteam/pypy-hippy-bridge/issues/15/echoing-of-a-python-module-in-php-is this change ensure that all wrappers are safely stringable, and that at-least something sensible is returned. Also fixes some crashes.

There are likely many other special methods which could do with the same treatment, however, I would argue that str() is the most useful for debugging, and thus high-priority.

Note the compromise for unbound PHP methods.

Small change on PyPy side: https://bitbucket.org/softdevteam/pypy-hippy-bridge/pull-requests/4/small-change-to-way-exception-adapter-is/diff -- please merge this also if you are happy.

No performance change.