### PR TITLE
Optimise iterating a Python list in PHP.

### DIFF
--- a/hippy/module/pypy_bridge/py_adapters.py
+++ b/hippy/module/pypy_bridge/py_adapters.py
@@ -348,16 +348,16 @@ class W_PyModAdapter(WPh_Object):
         return self.py_space.str_w(w_py_str)
 
 class W_PyListAdapterIterator(BaseIterator):
-    _immutable_fields_ = ["py_space", "storage_w"]
+    _immutable_fields_ = ["py_space", "w_py_list", "num_elems"]
 
     def __init__(self, py_space, w_py_list):
         self.py_space = py_space
-        self.storage_w = py_space.listview(w_py_list)
+        self.w_py_list = w_py_list
         self.index = 0
 
-        # By PHP semantics, the elements the iterator see cannot change.  It is
+        # By PHP semantics, the elements the iterator see cannot change. It is
         # therefore safe to count the elements once as the iterator is built.
-        self.num_elems = len(self.storage_w)
+        self.num_elems = py_space.int_w(py_space.len(w_py_list))
 
         self._compute_finished_flag()
 
@@ -371,14 +371,14 @@ class W_PyListAdapterIterator(BaseIterator):
 
     def next(self, space):
         index = self.index
-        w_py_value = self.storage_w[index]
+        w_py_value = self.py_space.getitem(self.w_py_list, self.py_space.wrap(self.index))
         self.index = index + 1
         self._compute_finished_flag()
         return w_py_value.to_php(self.py_space.get_php_interp())
 
     def next_item(self, space):
         index = self.index
-        w_py_value = self.storage_w[index]
+        w_py_value = self.py_space.getitem(self.w_py_list, self.py_space.wrap(self.index))
         self.index = index + 1
         self._compute_finished_flag()
         return space.wrap(index), \

--- a/hippy/module/pypy_bridge/py_adapters.py
+++ b/hippy/module/pypy_bridge/py_adapters.py
@@ -354,7 +354,15 @@ class W_PyListAdapterIterator(BaseIterator):
         self.py_space = py_space
         self.storage_w = py_space.listview(w_py_list)
         self.index = 0
-        self.finished = len(self.storage_w) == 0
+
+        # By PHP semantics, the elements the iterator see cannot change.  It is
+        # therefore safe to count the elements once as the iterator is built.
+        self.num_elems = len(self.storage_w)
+
+        self._compute_finished_flag()
+
+    def _compute_finished_flag(self):
+        self.finished = self.index == self.num_elems
 
     def get_wrapped_py_obj(self):
         # Iterators can reasonably be considered opaque from a wrapping
@@ -365,14 +373,14 @@ class W_PyListAdapterIterator(BaseIterator):
         index = self.index
         w_py_value = self.storage_w[index]
         self.index = index + 1
-        self.finished = self.index == len(self.storage_w)
+        self._compute_finished_flag()
         return w_py_value.to_php(self.py_space.get_php_interp())
 
     def next_item(self, space):
         index = self.index
         w_py_value = self.storage_w[index]
         self.index = index + 1
-        self.finished = self.index == len(self.storage_w)
+        self._compute_finished_flag()
         return space.wrap(index), \
                 w_py_value.to_php(self.py_space.get_php_interp())
 


### PR DESCRIPTION
Improves the speed of two of our "reverse" benchmarks. A reverse benchmark is a composed benchmark in the opposite direction. E.g. " composed" is PHP->Py, "composed-reverse" is Py->PHP.

```
+------------------+-------------------+------------------+----------+----------+
| Benchmark        |         VM        |     Variant      |  Seconds |    Error |
+------------------+-------------------+------------------+----------+----------+
| pb_lists         | PyHypNew (warm=7) |     composed     | 0.447600 | 0.000633 |
| pb_lists         | PyHypNew (warm=7) | composed-reverse | 0.248454 | 0.000318 |
| pb_lists         | PyHypOld (warm=7) |     composed     | 0.444922 | 0.001961 |
| pb_lists         | PyHypOld (warm=7) | composed-reverse | 0.369065 | 0.000388 |
---------------------------------------------------------------------------------
| pb_total_list    | PyHypNew (warm=7) |     composed     | 0.386764 | 0.000348 |
| pb_total_list    | PyHypNew (warm=7) | composed-reverse | 0.584158 | 0.000421 |
| pb_total_list    | PyHypOld (warm=7) |     composed     | 0.391179 | 0.000294 |
| pb_total_list    | PyHypOld (warm=7) | composed-reverse | 1.232246 | 0.001003 |
---------------------------------------------------------------------------------
```

All other benchmarks are unaffected.

Speedup comes from *not* using listview(), which was causing a copy.

I also tried wrapping a PyPy `W_FastListIterObject` but this turned out to give a less dramatic speedup (https://github.com/hippyvm/hippyvm/commit/837185350c6dc17e957e1367623beacaae9709d8).

Looks good, OK?