### PR TITLE
Fixed copy pasted error handling.

### DIFF
--- a/hippy/frame.py
+++ b/hippy/frame.py
@@ -41,7 +41,7 @@ class CatchBlock(ExceptionHandler):
             try:
                 w_py_cls = interp.py_space.builtin.get(self.exc_class)
             except OperationError as e:
-                if not e.match(space, space.w_KeyError):
+                if not e.match(interp.py_space, interp.py_space.w_AttributeError):
                     raise
                 return False
         else:

--- a/testing/test_pypy_bridge_exceptions.py
+++ b/testing/test_pypy_bridge_exceptions.py
@@ -187,6 +187,21 @@ class TestPyPyBridgeExceptions(BaseTestInterpreter):
 
         assert php_space.str_w(output[0]) == "oh no!"
 
+    def test_php_ignore_nonexisting_exception_type(self, php_space):
+        output = self.run('''
+            $src = "def raise_ex(): raise ValueError('my error')";
+            $raise_ex = compile_py_func($src);
+            try {
+                $raise_ex();
+            } catch (DoesNotExistsException $e) {
+                echo "bad";
+            } catch (ValueError $e) {
+                echo "oh no!";
+            }
+        ''')
+
+        assert php_space.str_w(output[0]) == "oh no!"
+
         # XXX more tests that check line number, trace, filename etc.
 
     @pytest.mark.xfail


### PR DESCRIPTION
Never just copy paste code...

Also the error thrown is an AttributeError and not an KeyError.

@cfbolz 
